### PR TITLE
修复自动贴图

### DIFF
--- a/MMT/migoto_format.py
+++ b/MMT/migoto_format.py
@@ -884,8 +884,9 @@ def create_material_with_texture(obj, mesh_name, directory):
     material_name = f"{mesh_name}_Material"
     texture_name = f"{mesh_name}-DiffuseMap.jpg"
 
-    texture_prefix = str(mesh_name).split("-")[0] # Hash值
-    texture_suffix = "-DiffuseMap.jpg"
+    real_mesh_name = str(mesh_name).split(".")[0]
+    texture_prefix, part_name = real_mesh_name.split("-") # IB Hash 和 PartName
+    texture_suffix = f"{part_name}-DiffuseMap.jpg"
 
     # Создание нового материала (Create new materials)
     material = bpy.data.materials.new(name=material_name)


### PR DESCRIPTION
MMT [v1.0.7.8](https://github.com/StarBobis/MigotoModTool/releases/tag/V1.0.7.8) 改变了贴图文件的命名方式（`IB Hash-文件Hash-PartName-别名`），但是插件里的好像并没有写对，简单改了一下。